### PR TITLE
fourbytes, openchain: rename `Version` to `DefaultVersion`

### DIFF
--- a/fourbytes/client.go
+++ b/fourbytes/client.go
@@ -25,7 +25,7 @@ type Client struct {
 
 func New(cfg *Config) (*Client, error) {
 	// Always set V1
-	cfg.Version = Version
+	cfg.Version = DefaultVersion
 
 	return &Client{
 		cfg: cfg,

--- a/fourbytes/client_test.go
+++ b/fourbytes/client_test.go
@@ -109,8 +109,8 @@ func TestTimeout(t *testing.T) {
 		timeout time.Duration
 		success bool
 	}{
-		{Version, 0, true},
-		{Version, time.Millisecond, false /* timeout */},
+		{DefaultVersion, 0, true},
+		{DefaultVersion, time.Millisecond, false /* timeout */},
 		{"unknown/", 0, true /* it should fail, but now it succeeds because the version is fixed. */},
 	}
 

--- a/fourbytes/config.go
+++ b/fourbytes/config.go
@@ -11,5 +11,5 @@ type Config struct {
 }
 
 func DefaultConfig() *Config {
-	return &Config{Version, 0}
+	return &Config{DefaultVersion, 0}
 }

--- a/fourbytes/types.go
+++ b/fourbytes/types.go
@@ -3,7 +3,7 @@ package fourbytes
 const (
 	BaseURL = "https://www.4byte.directory/api/"
 
-	Version = "v1"
+	DefaultVersion = "v1"
 )
 
 /*

--- a/openchain/client.go
+++ b/openchain/client.go
@@ -26,7 +26,7 @@ type Client struct {
 // timeout is in seconds, where 0 means no timeout.
 func New(cfg *Config) (*Client, error) {
 	// Always set V1
-	cfg.Version = Version
+	cfg.Version = DefaultVersion
 
 	return &Client{
 		cfg: cfg,

--- a/openchain/client_test.go
+++ b/openchain/client_test.go
@@ -120,8 +120,8 @@ func TestTimeout(t *testing.T) {
 		timeout time.Duration
 		success bool
 	}{
-		{Version, 0, true},
-		{Version, time.Millisecond, false /* timeout */},
+		{DefaultVersion, 0, true},
+		{DefaultVersion, time.Millisecond, false /* timeout */},
 		{"unknown/", 0, true /* it should fail, but now it succeeds because the version is fixed. */},
 	}
 

--- a/openchain/config.go
+++ b/openchain/config.go
@@ -11,5 +11,5 @@ type Config struct {
 }
 
 func DefaultConfig() *Config {
-	return &Config{Version, 0}
+	return &Config{DefaultVersion, 0}
 }

--- a/openchain/types.go
+++ b/openchain/types.go
@@ -3,7 +3,7 @@ package openchain
 const (
 	BaseURL = "https://api.openchain.xyz/signature-database/"
 
-	Version = "v1"
+	DefaultVersion = "v1"
 )
 
 /*


### PR DESCRIPTION
I'm a little hesitant to change the name of the external exposure variable that users use, but if we have to change it, do it quickly.