### PR TITLE
fourbytes, openchain: remove version from client config

### DIFF
--- a/fourbytes/client.go
+++ b/fourbytes/client.go
@@ -24,9 +24,6 @@ type Client struct {
 }
 
 func New(cfg *Config) (*Client, error) {
-	// Always set V1
-	cfg.Version = DefaultVersion
-
 	return &Client{
 		cfg: cfg,
 		caller: &http.Client{
@@ -90,8 +87,8 @@ func (c *Client) SignatureWithBytes(id []byte) ([]string, error) {
 	return c.Signature(common.Bytes2Hex(id))
 }
 
-func (c *Client) doRequest(ctx context.Context, api, method string, response interface{}, body io.Reader, opt option.Option) (int, error) {
-	var url = fmt.Sprintf("%s%s%s", BaseURL, c.cfg.Version, api)
+func (c *Client) doRequest(ctx context.Context, version, api, method string, response interface{}, body io.Reader, opt option.Option) (int, error) {
+	var url = fmt.Sprintf("%s%s%s", BaseURL, version, api)
 	if opt != nil {
 		query, err := opt.Encode()
 		if err != nil {

--- a/fourbytes/client.go
+++ b/fourbytes/client.go
@@ -87,10 +87,10 @@ func (c *Client) SignatureWithBytes(id []byte) ([]string, error) {
 	return c.Signature(common.Bytes2Hex(id))
 }
 
-func (c *Client) doRequest(ctx context.Context, version, api, method string, response interface{}, body io.Reader, opt option.Option) (int, error) {
+func (c *Client) doRequest(ctx context.Context, version, api, method string, response interface{}, body io.Reader, opts option.Option) (int, error) {
 	var url = fmt.Sprintf("%s%s%s", BaseURL, version, api)
-	if opt != nil {
-		query, err := opt.Encode()
+	if opts != nil {
+		query, err := opts.Encode()
 		if err != nil {
 			return 0, err
 		}

--- a/fourbytes/client_test.go
+++ b/fourbytes/client_test.go
@@ -1,7 +1,6 @@
 package fourbytes
 
 import (
-	"net/http"
 	"testing"
 	"time"
 )
@@ -92,30 +91,18 @@ func TestSignatureWithBytes(t *testing.T) {
 	}
 }
 
-func TestInvalidVersion(t *testing.T) {
-	c := Client{
-		cfg:    &Config{Version: "unknown/"},
-		caller: &http.Client{},
-	}
-
-	if _, err := c.Signature("0xa9059cbb"); err == nil {
-		t.Fatal("TestInvalidVersion: version (unknown/) must be fail")
-	}
-}
-
 func TestTimeout(t *testing.T) {
 	testset := []struct {
-		version string
 		timeout time.Duration
 		success bool
 	}{
-		{DefaultVersion, 0, true},
-		{DefaultVersion, time.Millisecond, false /* timeout */},
-		{"unknown/", 0, true /* it should fail, but now it succeeds because the version is fixed. */},
+		{0, true},
+		{time.Millisecond, false /* timeout */},
+		{0, true /* it should fail, but now it succeeds because the version is fixed. */},
 	}
 
 	for _, task := range testset {
-		c, err := New(&Config{task.version, task.timeout})
+		c, err := New(&Config{task.timeout})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/fourbytes/config.go
+++ b/fourbytes/config.go
@@ -3,13 +3,10 @@ package fourbytes
 import "time"
 
 type Config struct {
-	// Version has no meaning until a later version.
-	Version string
-
 	// Seconds, 0 means no timeout.
 	Timeout time.Duration
 }
 
 func DefaultConfig() *Config {
-	return &Config{DefaultVersion, 0}
+	return &Config{0}
 }

--- a/fourbytes/event.go
+++ b/fourbytes/event.go
@@ -41,6 +41,6 @@ func (c *Client) EventSignatureV1(ctx context.Context, opts EventSigV1Options) (
 		err        error
 	)
 
-	statusCode, err = c.doRequest(ctx, "/event-signatures", http.MethodGet, &res, nil, &opts)
+	statusCode, err = c.doRequest(ctx, v1, "/event-signatures", http.MethodGet, &res, nil, &opts)
 	return &res, statusCode, err
 }

--- a/fourbytes/method.go
+++ b/fourbytes/method.go
@@ -41,6 +41,6 @@ func (c *Client) MethodSignatureV1(ctx context.Context, opts MethodSigV1Options)
 		err        error
 	)
 
-	statusCode, err = c.doRequest(ctx, "/signatures", http.MethodGet, &res, nil, &opts)
+	statusCode, err = c.doRequest(ctx, v1, "/signatures", http.MethodGet, &res, nil, &opts)
 	return &res, statusCode, err
 }

--- a/fourbytes/types.go
+++ b/fourbytes/types.go
@@ -2,8 +2,7 @@ package fourbytes
 
 const (
 	BaseURL = "https://www.4byte.directory/api/"
-
-	DefaultVersion = "v1"
+	v1      = "v1"
 )
 
 /*

--- a/openchain/client.go
+++ b/openchain/client.go
@@ -25,9 +25,6 @@ type Client struct {
 
 // timeout is in seconds, where 0 means no timeout.
 func New(cfg *Config) (*Client, error) {
-	// Always set V1
-	cfg.Version = DefaultVersion
-
 	return &Client{
 		cfg: cfg,
 		caller: &http.Client{
@@ -97,8 +94,8 @@ func (c *Client) SignatureWithBytes(id []byte) ([]string, error) {
 	return c.Signature(common.Bytes2Hex(id))
 }
 
-func (c *Client) doRequest(ctx context.Context, api, method string, response interface{}, body io.Reader, opt option.Option) (int, error) {
-	var url = fmt.Sprintf("%s%s%s", BaseURL, c.cfg.Version, api)
+func (c *Client) doRequest(ctx context.Context, version, api, method string, response interface{}, body io.Reader, opt option.Option) (int, error) {
+	var url = fmt.Sprintf("%s%s%s", BaseURL, version, api)
 	if opt != nil {
 		query, err := opt.Encode()
 		if err != nil {

--- a/openchain/client.go
+++ b/openchain/client.go
@@ -94,10 +94,10 @@ func (c *Client) SignatureWithBytes(id []byte) ([]string, error) {
 	return c.Signature(common.Bytes2Hex(id))
 }
 
-func (c *Client) doRequest(ctx context.Context, version, api, method string, response interface{}, body io.Reader, opt option.Option) (int, error) {
+func (c *Client) doRequest(ctx context.Context, version, api, method string, response interface{}, body io.Reader, opts option.Option) (int, error) {
 	var url = fmt.Sprintf("%s%s%s", BaseURL, version, api)
-	if opt != nil {
-		query, err := opt.Encode()
+	if opts != nil {
+		query, err := opts.Encode()
 		if err != nil {
 			return 0, err
 		}

--- a/openchain/client_test.go
+++ b/openchain/client_test.go
@@ -1,7 +1,6 @@
 package openchain
 
 import (
-	"net/http"
 	"testing"
 	"time"
 )
@@ -103,30 +102,18 @@ func TestSignatureNotFound(t *testing.T) {
 	}
 }
 
-func TestInvalidVersion(t *testing.T) {
-	c := Client{
-		cfg:    &Config{Version: "unknown/"},
-		caller: &http.Client{},
-	}
-
-	if _, err := c.Signature("0xa9059cbb"); err == nil {
-		t.Fatal("TestInvalidVersion: version (unknown/) must be fail")
-	}
-}
-
 func TestTimeout(t *testing.T) {
 	testset := []struct {
-		version string
 		timeout time.Duration
 		success bool
 	}{
-		{DefaultVersion, 0, true},
-		{DefaultVersion, time.Millisecond, false /* timeout */},
-		{"unknown/", 0, true /* it should fail, but now it succeeds because the version is fixed. */},
+		{0, true},
+		{time.Millisecond, false /* timeout */},
+		{0, true /* it should fail, but now it succeeds because the version is fixed. */},
 	}
 
 	for _, task := range testset {
-		c, err := New(&Config{Version: task.version, Timeout: task.timeout})
+		c, err := New(&Config{Timeout: task.timeout})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/openchain/config.go
+++ b/openchain/config.go
@@ -3,13 +3,10 @@ package openchain
 import "time"
 
 type Config struct {
-	// Version has no meaning until a later version.
-	Version string
-
 	// Seconds, 0 means no timeout.
 	Timeout time.Duration
 }
 
 func DefaultConfig() *Config {
-	return &Config{DefaultVersion, 0}
+	return &Config{0}
 }

--- a/openchain/lookup.go
+++ b/openchain/lookup.go
@@ -62,6 +62,6 @@ func (c *Client) LookupV1(ctx context.Context, opts LookupV1Options) (*Signature
 		err        error
 	)
 
-	statusCode, err = c.doRequest(ctx, "/lookup", http.MethodGet, &res, nil, &opts)
+	statusCode, err = c.doRequest(ctx, v1, "/lookup", http.MethodGet, &res, nil, &opts)
 	return &res, statusCode, err
 }

--- a/openchain/stats.go
+++ b/openchain/stats.go
@@ -12,6 +12,6 @@ func (c *Client) StatsV1(ctx context.Context) (*StatsResponse, int, error) {
 		err        error
 	)
 
-	statusCode, err = c.doRequest(ctx, "/stats", http.MethodGet, &res, nil, nil)
+	statusCode, err = c.doRequest(ctx, v1, "/stats", http.MethodGet, &res, nil, nil)
 	return &res, statusCode, err
 }

--- a/openchain/types.go
+++ b/openchain/types.go
@@ -2,8 +2,7 @@ package openchain
 
 const (
 	BaseURL = "https://api.openchain.xyz/signature-database/"
-
-	DefaultVersion = "v1"
+	v1      = "v1"
 )
 
 /*


### PR DESCRIPTION
Each client has a version-specific method implementation, so we don't need to provide a version at client creation time.