### PR TITLE
fourbytes, openchain: add Config validation logics

### DIFF
--- a/fourbytes/client.go
+++ b/fourbytes/client.go
@@ -23,7 +23,16 @@ type Client struct {
 	caller *http.Client
 }
 
+// timeout is in seconds, where 0 means no timeout.
 func New(cfg *Config) (*Client, error) {
+	if cfg == nil {
+		cfg = DefaultConfig()
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
 	return &Client{
 		cfg: cfg,
 		caller: &http.Client{

--- a/fourbytes/config.go
+++ b/fourbytes/config.go
@@ -7,6 +7,10 @@ type Config struct {
 	Timeout time.Duration
 }
 
+func (c *Config) validate() error {
+	return nil
+}
+
 func DefaultConfig() *Config {
 	return &Config{0}
 }

--- a/openchain/client.go
+++ b/openchain/client.go
@@ -25,6 +25,14 @@ type Client struct {
 
 // timeout is in seconds, where 0 means no timeout.
 func New(cfg *Config) (*Client, error) {
+	if cfg == nil {
+		cfg = DefaultConfig()
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
 	return &Client{
 		cfg: cfg,
 		caller: &http.Client{

--- a/openchain/config.go
+++ b/openchain/config.go
@@ -7,6 +7,10 @@ type Config struct {
 	Timeout time.Duration
 }
 
+func (c *Config) validate() error {
+	return nil
+}
+
 func DefaultConfig() *Config {
 	return &Config{0}
 }


### PR DESCRIPTION
Adds `Config` validation logic. If empty, use DefaultConfig.